### PR TITLE
Engine update (2026-01-24)

### DIFF
--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="e2140"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="d6e225715863c06d71beb362c4bf790723bc462f"
+ENGINE_VERSION="f827421b37032c17d20fe7b25d98b96580ed9be8"
 
 ##############################################################################
 # Packaging

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="e2140"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="4a04f8df83fe936bf5e937b51be2e688a3c2b017"
+ENGINE_VERSION="f827421b37032c17d20fe7b25d98b96580ed9be8"
 
 ##############################################################################
 # Packaging

--- a/mod.config
+++ b/mod.config
@@ -102,7 +102,7 @@ PACKAGING_OVERWRITE_MOD_VERSION="True"
 AUTOMATIC_ENGINE_MANAGEMENT="True"
 
 # The URL to download the engine files from when AUTOMATIC_ENGINE_MANAGEMENT is enabled.
-AUTOMATIC_ENGINE_SOURCE="https://github.com/OpenRA/OpenRA/archive/${ENGINE_VERSION}.zip"
+AUTOMATIC_ENGINE_SOURCE="https://github.com/michaeldgg2/OpenRA/archive/${ENGINE_VERSION}.zip"
 
 # Temporary file/directory names used by automatic engine management.
 # Paths outside the SDK directory are not officially supported.

--- a/mod.config
+++ b/mod.config
@@ -9,7 +9,7 @@
 MOD_ID="e2140"
 
 # The OpenRA engine version to use for this project.
-ENGINE_VERSION="f827421b37032c17d20fe7b25d98b96580ed9be8"
+ENGINE_VERSION="d6e225715863c06d71beb362c4bf790723bc462f"
 
 ##############################################################################
 # Packaging


### PR DESCRIPTION
Automated engine update to commit f827421b37032c17d20fe7b25d98b96580ed9be8

Compare changes: https://github.com/michaeldgg2/OpenRA/compare/d6e225715863c06d71beb362c4bf790723bc462f...f827421b37032c17d20fe7b25d98b96580ed9be8

Commits included:
- [f8c20a0: Update to SDL 2.32.10](https://github.com/michaeldgg2/OpenRA/commit/f8c20a0f8d53e17e210c027e09cbd6f9913dadb6)
- [d6af55b: Display the complete SDL version.](https://github.com/michaeldgg2/OpenRA/commit/d6af55bc04c76d1b33a440f26b062f84abdb037a)
- [2164700: Fix field saver tests not ignoring culture](https://github.com/michaeldgg2/OpenRA/commit/2164700a7a7a65e87ada65edc1db76dd0e15b214)
- [ac16293: These strings are already shared.](https://github.com/michaeldgg2/OpenRA/commit/ac162936caaec7f08ee28f91d146bf38be76c8c8)
- [f827421: Deduplicate ingame player strings.](https://github.com/michaeldgg2/OpenRA/commit/f827421b37032c17d20fe7b25d98b96580ed9be8)

Related pull requests:
- [#22315: Update SDL to 2.32.10](https://github.com/OpenRA/OpenRA/pull/22315) (Mailaender)
- [#22320: Fix field saver tests not ignoring culture](https://github.com/OpenRA/OpenRA/pull/22320) (PunkPun)
- [#22311: Deduplicate ingame player fluent strings](https://github.com/OpenRA/OpenRA/pull/22311) (Mailaender)